### PR TITLE
Fix issue where conservation isn't used

### DIFF
--- a/FullSend/settings.py
+++ b/FullSend/settings.py
@@ -137,3 +137,6 @@ sentry_sdk.init(
 SECURE_SSL_REDIRECT = True
 SESSION_COOKIE_SECURE = True
 CSRF_COOKIE_SECURE = True
+
+# Use BackgroundScheduler to keep api token alive
+import api.conservation


### PR DESCRIPTION
Conservation isn't imported anywhere so the backgroundscheduler never gets loaded into memory, so load it in the settings